### PR TITLE
fix: make turndown-plugin-gfm resolution robust in npx installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@just-every/crawl": "^1.0.8",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^14.0.3",
+        "turndown-plugin-gfm": "^1.0.2",
         "uuid": "^13.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@just-every/crawl": "^1.0.8",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^14.0.3",
+    "turndown-plugin-gfm": "^1.0.2",
     "uuid": "^13.0.0"
   },
   "devDependencies": {

--- a/src/internal/turndownPluginGfmCompat.ts
+++ b/src/internal/turndownPluginGfmCompat.ts
@@ -2,11 +2,31 @@ import { createRequire } from 'node:module';
 
 type GfmPlugin = (service: unknown) => void;
 
-const require = createRequire(import.meta.url);
-const turndownPluginGfmModule = require('turndown-plugin-gfm') as {
+const requireFromHere = createRequire(import.meta.url);
+
+function loadTurndownPluginGfmModule(): {
     default?: { gfm?: GfmPlugin };
     gfm?: GfmPlugin;
-};
+} {
+    try {
+        return requireFromHere('turndown-plugin-gfm') as {
+            default?: { gfm?: GfmPlugin };
+            gfm?: GfmPlugin;
+        };
+    } catch {
+        const crawlPackageJsonPath = requireFromHere.resolve(
+            '@just-every/crawl/package.json'
+        );
+        const requireFromCrawl = createRequire(crawlPackageJsonPath);
+
+        return requireFromCrawl('turndown-plugin-gfm') as {
+            default?: { gfm?: GfmPlugin };
+            gfm?: GfmPlugin;
+        };
+    }
+}
+
+const turndownPluginGfmModule = loadTurndownPluginGfmModule();
 
 export const gfm =
     turndownPluginGfmModule.gfm ?? turndownPluginGfmModule.default?.gfm;


### PR DESCRIPTION
This probably fixes 'MCP error -32603: Failed to fetch content: Cannot find module 'turndown-plugin-gfm', but I'm not really sure at this point lol 